### PR TITLE
Take in number of move-forward/backward

### DIFF
--- a/Board Game Tool/Collection Game Tool Test/ServicesTests/BoardGenTest.cs
+++ b/Board Game Tool/Collection Game Tool Test/ServicesTests/BoardGenTest.cs
@@ -38,7 +38,7 @@ namespace Collection_Game_Tool_Test.ServicesTests
             int numberOfExpectedMoveBack = 5;
             int numberOfExpectedMoveForward = 5;
             int numberOfExpectedextraGames = 3;
-            ITile firstTile = bg.genBoard(boardSize, 1, 2, true, true, true, prizes, 1, 2);
+            ITile firstTile = bg.genBoard(boardSize, 1, 2, numberOfExpectedMoveBack, numberOfExpectedMoveForward, numberOfExpectedextraGames, prizes, 1, 2);
             
             int numberOfCollection = 0;
             int numberOfMoveBack = 0;

--- a/Board Game Tool/Collection Game Tool/Services/BoardGeneration.cs
+++ b/Board Game Tool/Collection Game Tool/Services/BoardGeneration.cs
@@ -38,9 +38,9 @@ namespace Collection_Game_Tool.Services
         public Tiles.ITile genBoard(int boardSize,
             int minMove,
             int maxMove,
-            bool moveBackInclude,
-            bool moveForwardInclude,
-            bool extraGameInclude,
+            int moveBackCount,
+            int moveForwardCount,
+            int extraGameCount,
             PrizeLevels.PrizeLevels prizes,
             int moveForward = 1,
             int moveBack =  1)
@@ -52,17 +52,17 @@ namespace Collection_Game_Tool.Services
             }
             fillInBlankBoardTiles(boardSize);
             fillInTiles(boardSize, minMove, maxMove, numberOfCollectionSpots, Tiles.TileTypes.collection);
-            if (moveBackInclude)
+            if (moveBackCount > 0)
             {
                 fillInTiles(boardSize, minMove, maxMove, (int)(Math.Round((double)(boardSize/5), MidpointRounding.AwayFromZero) + 1), Tiles.TileTypes.moveBack);
 
             }
-            if (moveForwardInclude)
+            if (moveForwardCount > 0)
             {
                 fillInTiles(boardSize, minMove, maxMove, (int)(Math.Round((double)(boardSize/5), MidpointRounding.AwayFromZero) + 1), Tiles.TileTypes.moveForward);
 
             }
-            if (extraGameInclude)
+            if (extraGameCount > 0)
             {
                 fillInTiles(boardSize, minMove, maxMove, (int)(Math.Round((double)(boardSize/10), MidpointRounding.AwayFromZero) + 1), Tiles.TileTypes.extraGame);
             }


### PR DESCRIPTION
The tests still pass, but they'll need to be changed when we change the generation to loop around the board when reaching the end of the board