### PR TITLE
Load project with 30 divisions properly

### DIFF
--- a/Board Game Tool/Collection Game Tool/Divisions/DivisionPanelUC.xaml.cs
+++ b/Board Game Tool/Collection Game Tool/Divisions/DivisionPanelUC.xaml.cs
@@ -81,7 +81,7 @@ namespace Collection_Game_Tool.Divisions
         /// <param name="div">The existing division</param>
         public void loadInDivision(DivisionModel div)
         {
-            if (MainWindowModel.Instance.DivisionsModel.getSize() < MAX_DIVISIONS)
+            if (MainWindowModel.Instance.DivisionsModel.getSize() <= MAX_DIVISIONS)
             {
                 int divNumber = divisionsHolderPanel.Children.Count + 1;
                 DivisionUC division = new DivisionUC(prizes, divNumber);


### PR DESCRIPTION
If a project has 30 divisions was saved and then loaded, it's division section would be empty, and the add division button would be disabled. This commit displays the divisions properly.